### PR TITLE
Fix handling of `using` argument in `alter_column_type`

### DIFF
--- a/pg_database/schema.py
+++ b/pg_database/schema.py
@@ -242,7 +242,7 @@ def alter_column_type(table_or_name, column_name, new_type, using=None):
 
     if using is not None:
         using = f"{column_name}::{using}"
-    if new_type != "bool":
+    elif new_type != "bool":
         using = f"{column_name}::{new_type}"
     else:
         using = f"CASE WHEN {column_name}::int=0 THEN FALSE WHEN {column_name} IS NULL THEN NULL ELSE TRUE END"


### PR DESCRIPTION
Currently, any `using` value passed to `alter_column_type` is overwritten by the following logic:

```python
if using is not None:
    using = f"{column_name}::{using}"
if new_type != "bool":
    using = f"{column_name}::{new_type}"
else:
    using = f"CASE WHEN {column_name}::int=0 THEN FALSE WHEN {column_name} IS NULL THEN NULL ELSE TRUE END"
```

Either `new_type` is "bool" or not, and in either case, any original value ends up being replaced.

This PR corrects the issue by replacing `if new_type != "bool"` to `elif new_type != "bool"`.