### PR TITLE
Quote column name in `drop_column` query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .cache/
 .coverage
+.tox/
 __pycache__/
 /build/
 /dist/

--- a/pg_database/schema.py
+++ b/pg_database/schema.py
@@ -371,9 +371,9 @@ def drop_column(table_or_name, column_name, checkfirst=False):
     validate_sql_params(table=table_name, column=column_name)
 
     if checkfirst:
-        drop_sql = f"ALTER TABLE {table_name} DROP COLUMN IF EXISTS {column_name}"
+        drop_sql = f'ALTER TABLE {table_name} DROP COLUMN IF EXISTS "{column_name}"'
     else:
-        drop_sql = f"ALTER TABLE {table_name} DROP COLUMN {column_name}"
+        drop_sql = f'ALTER TABLE {table_name} DROP COLUMN "{column_name}"'
 
     logger.info(f"drop_column: dropping {table_name}.{column_name}")
 

--- a/pg_database/sql.py
+++ b/pg_database/sql.py
@@ -558,7 +558,7 @@ def _values(element, compiler, **kwargs):
     :see: https://www.postgresql.org/docs/current/queries-values.html
     """
 
-    value_cols = ",".join(element.cols)
+    value_cols = ",".join('"{}"'.format(c.strip("'\"")) for c in element.cols)
     value_sets = ", ".join(
         "({values})".format(
             values=",".join(_compile_value(compiler, val, element.types[idx]) for idx, val in enumerate(tup))

--- a/pg_database/tests/tests.py
+++ b/pg_database/tests/tests.py
@@ -70,6 +70,7 @@ SITE_TABLE_COLS = (
     "test_geom",
     "test_line",
     "test_poly",
+    "TEST_CAPS",
 )
 SEARCHABLE_COLS = ("obj_hash", "site_addr", "site_city", "site_state", "site_zip", "countyname")
 
@@ -91,6 +92,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "1",
@@ -109,6 +111,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "2",
@@ -127,6 +130,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "3",
@@ -145,6 +149,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "4",
@@ -163,6 +168,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "5",
@@ -181,6 +187,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "6",
@@ -199,6 +206,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "7",
@@ -217,6 +225,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
     {
         "pk": "8",
@@ -235,6 +244,7 @@ SITE_TEST_DATA = [
         "test_geom": None,
         "test_line": None,
         "test_poly": None,
+        "TEST_CAPS": "Test",
     },
 ]
 SITE_DATA_DICT = {obj["pk"]: obj for obj in SITE_TEST_DATA}
@@ -1951,6 +1961,13 @@ def test_drop_column(db_metadata):
     # Test for the presence and removal of an indexed column
 
     column = "obj_order"
+    assert column in site_table.columns
+    schema.drop_column(site_table, column)
+    assert column not in refresh_metadata(db_metadata).tables[site_table.name].columns
+
+    # Test that columns with upper case letters can be dropped
+
+    column = "TEST_CAPS"
     assert column in site_table.columns
     schema.drop_column(site_table, column)
     assert column not in refresh_metadata(db_metadata).tables[site_table.name].columns

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,10 @@ deps =
     Django
     {[base]deps}
 
+[testenv:nodjango]
+deps =
+    {[base]deps}
+
 [testenv:coverage]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =


### PR DESCRIPTION
The `drop_column` function fails for a column name with any upper case letters. This PR quotes the column name in the query so that it will work with column names including upper case letters.

This fix is high priority for the CRP project.

In the process of adding a test for dropping a column with upper-case letters, I discovered another test failure with upper-case columns. This led me to also fix the `Values` clause for upper-case column names.